### PR TITLE
kmodes 0.12.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,22 +7,23 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/kmodes-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d840ac9f4616a668ebacba24a12ec1def87da24a9fd0a0dc2f7499a9b9a6f45b
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv -no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
+    - python
     - joblib >=0.11
     - numpy >=1.10.4
-    - python >=3.6
     - scikit-learn >=0.22.0
     - scipy >=0.13.3
 
@@ -30,10 +31,10 @@ test:
   imports:
     - kmodes
     - kmodes.util
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/nicodv/kmodes
@@ -41,6 +42,8 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Python implementations of the k-modes and k-prototypes clustering algorithms for clustering categorical data.
+  description: |
+    Python implementations of the k-modes and k-prototypes clustering algorithms for clustering categorical data.
   doc_url: https://pypi.org/project/kmodes/
   dev_url: https://github.com/nicodv/kmodes
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv -no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:


### PR DESCRIPTION
Changelog: https://github.com/nicodv/kmodes/releases
License: https://github.com/nicodv/kmodes/blob/0.12.2/LICENSE
Requirements: https://github.com/nicodv/kmodes/blob/0.12.2/setup.py

Actions:
1. Remove `noarch python`
2. Add flags `--no-deps --no-build-isolation` to `script`
3. Add missing `setuptools` and `wheel` to `host`
4. Fix `python` in `host` and `run`
5. Add `description` 

Notes:
- pycaret 3.0.2 (subpackage pycaret-models) relies on it https://github.com/pycaret/pycaret/blob/fdc3f7d22a4117577340be6d8fe2db2a889e9d82/requirements-optional.txt#L16